### PR TITLE
fix: 让已认证的 LAN 浏览器在客户端初始化阶段获得可信设置权限

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -11,6 +11,7 @@ A Cordis plugin that puts an authentication gate in front of the [DeepSeek Harne
 - **Password auth**: on first deployment an initial password is auto-generated and printed to the console (one-time credential); after login you are guided to set a personal password (scrypt-hashed), and every subsequent visit requires login;
 - **Two-factor authentication (TOTP)**: optional; works with Google Authenticator, Authy, 1Password and other mainstream authenticators; ships with one-time backup codes (scrypt-hashed, single-use) for recovery when a device is lost; **the OTP secret is stored encrypted at rest with AES-256-GCM** (master key from the `DSH_AUTH_GATEWAY_MASTER_KEY` env var or an auto-generated `auth-gate/otp-master.key`), so a disk disclosure no longer exposes the second-factor root key;
 - **Real request interception**: unauthenticated `/api/*` returns 401, page paths 302 to the login page, WebSocket upgrades are rejected outright; authenticated traffic is forwarded transparently (Host/Origin normalization, compatible with the internal trust fence);
+- **Authenticated LAN settings support**: before dsh client modules initialize, browsers reached through the gateway receive loopback-trusted connection state, enabling Models, Credentials, locale/theme preferences, and other host-backed settings to load and persist;
 - **Layered brute-force protection**: per-source lockout on password failures (default 5 failures / 5 min) + global rate limit (default 60 attempts/min) + per-source OTP/backup-code limit (default 10/min); scrypt runs asynchronously on the libuv thread pool, so login floods never block the event loop;
 - **Session management**: in-memory 256-bit tokens (30 days), HttpOnly + SameSite=Strict cookies; changing the password or disabling OTP revokes all sessions;
 - **Security events**: lockouts and exhausted rate-limit windows log warnings and broadcast a `dsh-auth-gateway/brute-force` Cordis event (JSON payload) for monitoring and automation;
@@ -50,6 +51,7 @@ Browser ──> dsh-auth-gateway gateway (external port, inside the dsh process)
 
 - The gateway's lifecycle is bound to dsh: it starts/stops with dsh, no separate process;
 - The bundle patch moves the webserver to a loopback port (external = `--port`, internal = external + 1), so remote clients cannot bypass the gateway and reach the backend directly;
+- The gateway establishes client-side loopback trust while dsh's `__ModuleLoader__` loads the connection module, before Settings consumers start. This compatibility layer does not replace login, the HTTP/WebSocket gates, or the server-side fence;
 - Auth state machine: `first deploy → initial-password login → onboarding (set a personal password) → login → (optional) OTP verification → session`; sessions that have not finished onboarding or 2FA can only reach their verification endpoints.
 
 ## Screenshots

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - **密码认证**：首次部署自动生成初始密码（控制台打印，一次性），登录后引导设置个人密码（scrypt 哈希存储），之后每次访问需登录；
 - **双因素认证（TOTP）**：可选启用，兼容 Google Authenticator、Authy、1Password 等主流认证器；含一次性备份代码（scrypt 哈希存储、单次使用），设备丢失时可恢复访问；**OTP 密钥以 AES-256-GCM 加密存储**（主密钥来自环境变量 `DSH_AUTH_GATEWAY_MASTER_KEY` 或自动生成的 `auth-gate/otp-master.key`），磁盘泄露不再直接暴露第二因素根密钥；
 - **真实请求拦截**：未认证 `/api/*` 返回 401、页面类路径 302 到登录页、WebSocket 升级直接拒绝；认证通过后请求透明转发（Host/Origin 规范化，兼容内部 trust fence）；
+- **认证后的 LAN 设置支持**：在 DSH 客户端模块初始化前，将经过网关访问的浏览器连接标记为 loopback-trusted，使 Models、Credentials、语言/主题偏好和其他 host-backed settings 可读取并持久化；
 - **多层防爆破**：密码失败按来源锁定（默认 5 次/5 分钟）+ 全局速率限制（默认 60 次/分钟）+ OTP/备份码独立限流（默认 10 次/分钟），scrypt 在 libuv 线程池异步执行，登录洪峰不阻塞事件循环；
 - **会话管理**：内存 256-bit token（30 天），HttpOnly + SameSite=Strict Cookie，修改密码/禁用 OTP 吊销全部会话；
 - **安全事件**：锁触发、限流耗尽时输出告警日志并广播 `dsh-auth-gateway/brute-force` Cordis 事件（JSON 负载），供监控与联动；
@@ -49,6 +50,7 @@ dsh web                 # 打开 http://<host>:<对外端口>
 
 - 网关生命周期与 dsh 绑定：随 dsh 启动/退出，无独立进程；
 - bundle patch 将 webserver 移到回环端口（对外 = `--port`，内部 = 对外 + 1），远程无法绕过网关直连后端；
+- 网关在 DSH 的 `__ModuleLoader__` 加载 connection 模块时、Settings 等消费者启动前建立客户端 loopback trust；该兼容层不替代登录、HTTP/WebSocket 门禁或服务端 fence；
 - 认证状态机：`首次部署 → 初始密码登录 → 引导（设置个人密码）→ 登录 →（可选）OTP 验证 → 会话`；未完成引导或 2FA 的会话仅能访问对应验证端点。
 
 ## 界面预览

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 ```
 host（零构建，node:crypto / node:http）
-├── index.js          # Cordis 插件入口：gateway 生命周期、tapIndex 注入（randomUUID polyfill）、安全事件接线
+├── index.js          # Cordis 插件入口：gateway 生命周期、tapIndex 注入（randomUUID + authenticated LAN trust）、安全事件接线
 ├── lib/gateway.js    # 认证网关：HTTP/WS 拦截与转发、认证状态机、防爆破三层、防重放
 ├── lib/gateway-otp.js # OTP 路由 handler（/otp/setup|enable|verify-setup|verify|verify-backup|disable，自 gateway.js 拆分）
 ├── lib/page-shell.js # 页面脚手架共享件（基础 CSS、HTML 骨架、script 头：ERRORS + post）
@@ -27,7 +27,8 @@ client（可选，源码构建）
 设计要点：
 
 - **零运行时依赖**：host 全部使用 Node 内置模块；client 构建产物仅 external 引用 dsh 运行时提供的模块；
-- **官方扩展点**：`ctx.effect`（生命周期）、`webServer.tapIndex`（polyfill 注入）、`ctx.slots`（client UI）、`ctx.emit`（安全事件）、`dsh.bundle`（组合 patch）；
+- **官方扩展点**：`ctx.effect`（生命周期）、`webServer.tapIndex`（randomUUID 与 authenticated LAN trust 注入）、`ctx.slots`（client UI）、`ctx.emit`（安全事件）、`dsh.bundle`（组合 patch）；
+- **客户端 trust 时序**：index transform 在 queue-mode `__ModuleLoader__` 建立后、parser preload 前插入 bootstrap；它同时包装 queue/live 注册，并在 `dsh-client-connection` 调用 `ctx.provide('connection', handle)` 前设置 `handle.isLoopback = true`，避免 Settings 过早绑定 memory scope。此处依赖 DSH 的内部 loader 协议，结构不匹配时只记录一次告警；
 - **存储**：原子写（temp + rename）、0600/0700，与密码同模式；OTP 密钥以 AES-256-GCM 加密存储（主密钥来自 `DSH_AUTH_GATEWAY_MASTER_KEY` 或 `auth-gate/otp-master.key`，见 SECURITY.md）。
 
 ## 构建

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -14,6 +14,7 @@
 | OTP 重放（同一验证码在窗口内复用） | 记录已接受时间步（`lastCounter`，持久化），同一步或更早步骤的验证码拒绝 |
 | 会话劫持（Cookie 窃取） | HttpOnly + SameSite=Strict；禁用 OTP、修改密码等敏感操作要求完整重验证 |
 | DNS-rebinding / 跨站请求 | 网关 Cookie 门禁接管（跨站请求无会话 Cookie 即被拒）；内部 fence 职责移交后，Host/Origin 改写为回环（见下） |
+| LAN 浏览器获得客户端 loopback trust | trust bootstrap 只随内部 DSH index 提供；外部浏览器必须先通过网关完整认证才能取得页面，内部 webserver 仍只监听回环，服务端 privileged fence 保持启用 |
 | 存储泄露（`$DSH_HOME` 文件被读取） | 密码与备份代码为 scrypt 哈希；**OTP 密钥为 AES-256-GCM 加密**（读取需主密钥，见"已知限制"） |
 | 首次部署抢占 | 初始密码由服务器自动生成（console 打印，本机可见）——无"先到先得"窗口；初始密码为一次性凭据，完成引导后失效 |
 
@@ -61,6 +62,12 @@ TOTP secret 是第二因素的根密钥：拿到它就能生成任意有效验�
 ### 转发与 fence
 
 网关转发前将 `Host`/`Origin` 改写为回环地址：内部 trust fence 的 LAN 信任列表基于 webserver 监听地址采样，而本插件将 webserver 钉在 `127.0.0.1`，若不改写则 LAN 访问会被内部 403。改写是安全的——fence 的远程可达性防护职责已由网关 Cookie 门禁接管（跨站/DNS-rebinding 请求无会话 Cookie，在网关即被拒绝）。
+
+### 认证后的浏览器 trust
+
+DSH 客户端会用页面 hostname 初始化 `connection.isLoopback`，并在 Settings 启动时一次性选择 host 或 memory scope。通过 LAN IP 访问时该值原本为 `false`，导致 Models、Credentials、Locale/Theme/Preferences 等 host-backed settings 在浏览器端被提前禁用，即使网关已经把服务端 Host/Origin 改写为回环也无法恢复。
+
+网关通过 `webServer.tapIndex` 在 DSH queue-mode `__ModuleLoader__` 之后、parser preload 之前插入兼容 bootstrap。bootstrap 只包装 `@deepseek-ai/dsh-client-connection`，并在其同步 `ctx.provide('connection', handle)` 发布服务前把 `handle.isLoopback` 设为 `true`；认证、HTTP/WS 拦截、Host/Origin 改写和服务端 privileged fence 均不变。对外页面仍必须先通过完整会话（含 onboarding/OTP）门禁；内部 DSH 必须继续只监听 `127.0.0.1`。若 loader 协议变化，网关记录兼容性告警而不会关闭任何安全检查。
 
 ## 已知限制
 

--- a/index.js
+++ b/index.js
@@ -28,12 +28,11 @@ export const inject = ['webServer']
 export async function apply(ctx, config) {
   const gateway = createGateway(config)
 
-  // Browser-side injection into every index.html response: the
-  // crypto.randomUUID polyfill — the API exists only in secure contexts
-  // (HTTPS or localhost); the gateway is meant to be reached over plain HTTP
-  // on a LAN IP, where dsh's frontend would crash on it. A small polyfill
-  // over getRandomValues (always available) restores it.
-  const injectedScript = '<script>'
+  // Browser-side compatibility for authenticated LAN pages. The randomUUID
+  // polyfill can run at the start of <head>. The trusted-loopback bootstrap
+  // must run later: after dsh creates its queue-mode __ModuleLoader__, but
+  // before parser-preloaded client bundles register their factories.
+  const randomUUIDScript = '<script>'
     + 'if (typeof crypto !== "undefined" && typeof crypto.randomUUID !== "function") {'
     + 'crypto.randomUUID = function () {'
     + 'var b = crypto.getRandomValues(new Uint8Array(16));'
@@ -44,10 +43,102 @@ export async function apply(ctx, config) {
     + '};'
     + '}'
     + '</script>'
-  ctx.effect(() => ctx.webServer.tapIndex((html) => html.replace(
-    '<head>',
-    `<head>${injectedScript}`,
-  )), 'dsh-auth-gateway: crypto.randomUUID polyfill')
+  const trustedLoopbackScript = `<script>(() => {
+  const targetId = "@deepseek-ai/dsh-client-connection"
+  const loader = globalThis.__ModuleLoader__
+  const bootstrapKey = "__dshAuthGatewayTrustedLoopbackBootstrap__"
+  if (loader && loader[bootstrapKey] === true) return
+  if (!loader || loader.mode !== "queue" || typeof loader.load !== "function" || typeof loader.create !== "function") {
+    console.error("dsh-auth-gateway: incompatible __ModuleLoader__ bootstrap; authenticated LAN settings remain unavailable")
+    return
+  }
+  Object.defineProperty(loader, bootstrapKey, { value: true, configurable: false, enumerable: false })
+
+  const wrappedFactories = new WeakSet()
+  const wrappedApplies = new WeakSet()
+  const wrappedLoads = new WeakSet()
+
+  const wrapRegistration = (registration) => {
+    if (!registration || (registration.id !== targetId && registration.id !== targetId + "/client")) return registration
+    const originalFactory = registration.factory
+    if (typeof originalFactory !== "function" || wrappedFactories.has(originalFactory)) return registration
+
+    const wrappedFactory = function () {
+      const moduleExports = originalFactory.apply(this, arguments)
+      if (!moduleExports || typeof moduleExports.apply !== "function" || wrappedApplies.has(moduleExports.apply)) return moduleExports
+      const originalApply = moduleExports.apply
+      const wrappedApply = function (ctx) {
+        const originalProvide = ctx.provide
+        ctx.provide = function (service, value) {
+          if (service === "connection") {
+            Object.defineProperty(value, "isLoopback", {
+              value: true,
+              writable: true,
+              configurable: true,
+              enumerable: true,
+            })
+          }
+          return originalProvide.apply(this, arguments)
+        }
+        try {
+          return originalApply.apply(this, arguments)
+        } finally {
+          ctx.provide = originalProvide
+        }
+      }
+      wrappedApplies.add(originalApply)
+      wrappedApplies.add(wrappedApply)
+      moduleExports.apply = wrappedApply
+      return moduleExports
+    }
+    wrappedFactories.add(originalFactory)
+    wrappedFactories.add(wrappedFactory)
+    registration.factory = wrappedFactory
+    return registration
+  }
+
+  const wrapLoad = () => {
+    const originalLoad = loader.load
+    if (wrappedLoads.has(originalLoad)) return
+    const wrappedLoad = function (registration) {
+      return originalLoad.call(this, wrapRegistration(registration))
+    }
+    wrappedLoads.add(wrappedLoad)
+    loader.load = wrappedLoad
+  }
+
+  wrapLoad()
+  const originalCreate = loader.create
+  loader.create = function () {
+    try {
+      return originalCreate.apply(this, arguments)
+    } finally {
+      wrapLoad()
+    }
+  }
+})()</script>`
+
+  let warnedMissingLoader = false
+  ctx.effect(() => ctx.webServer.tapIndex((html) => {
+    const withRandomUUID = html.replace('<head>', `<head>${randomUUIDScript}`)
+    const loaderMarker = 'window.__ModuleLoader__='
+    const loaderStart = withRandomUUID.indexOf(loaderMarker)
+    const loaderEnd = loaderStart === -1 ? -1 : withRandomUUID.indexOf('</script>', loaderStart)
+    if (loaderStart === -1 || loaderEnd === -1) {
+      if (!warnedMissingLoader) {
+        warnedMissingLoader = true
+        ctx.logger.warn(
+          '[dsh-auth-gateway] dsh client module bootstrap not found; '
+          + 'authenticated LAN settings compatibility was not installed',
+        )
+      }
+      return withRandomUUID
+    }
+    const insertAt = loaderEnd + '</script>'.length
+    return withRandomUUID.slice(0, insertAt)
+      + trustedLoopbackScript
+      + withRandomUUID.slice(insertAt)
+  }), 'dsh-auth-gateway: authenticated LAN browser compatibility')
 
   // Safety net: the whole design assumes the internal webserver is loopback-only.
   // The bundle patch enforces it, but a manual composition may forget.

--- a/tests/plugin-contract.test.mjs
+++ b/tests/plugin-contract.test.mjs
@@ -10,7 +10,13 @@
 
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import net from 'node:net'
+import vm from 'node:vm'
 import * as mod from '../index.js'
+import { setPassword } from '../lib/store.js'
 
 test('module satisfies the Cordis plugin contract', () => {
   // Loader normalize step (vendor/loader/src/index.ts): prefer default export.
@@ -36,6 +42,234 @@ test('resolveConfig step validates before apply (fiber semantics)', () => {
   const bad = pluginConfig({ listenPort: 99999 })
   assert.equal(bad, undefined, 'invalid config must be rejected')
 })
+
+test('authenticated LAN bootstrap patches connection before service publication', async () => {
+  const capture = await captureIndexTransform()
+  try {
+    const loaderScript = `<script>(() => {
+const pendingQueue = []
+window.__ModuleLoader__={
+  mode:"queue",
+  pendingQueue,
+  load(registration){pendingQueue.push(registration)},
+  create(){
+    const live = []
+    this.mode = "live"
+    this.load = (registration) => { live.push(registration) }
+    for (const registration of pendingQueue.splice(0)) this.load(registration)
+    return live
+  }
+}
+})()</script>`
+    const preload = '<script src="/plugins/@deepseek-ai/dsh-client-modules/client.js?rev=test"></script>'
+    const html = `<!doctype html><html><head>${loaderScript}${preload}</head><body></body></html>`
+    const transformed = capture.transform(html)
+
+    const polyfillAt = transformed.indexOf('crypto.randomUUID')
+    const loaderAt = transformed.indexOf('window.__ModuleLoader__=')
+    const trustAt = transformed.indexOf('__dshAuthGatewayTrustedLoopbackBootstrap__')
+    const preloadAt = transformed.indexOf(preload)
+    assert.ok(polyfillAt !== -1, 'the existing randomUUID polyfill is retained')
+    assert.ok(polyfillAt < loaderAt, 'the randomUUID polyfill remains first in head')
+    assert.ok(loaderAt < trustAt, 'trusted bootstrap runs after the queue loader exists')
+    assert.ok(trustAt < preloadAt, 'trusted bootstrap runs before parser-preloaded bundles')
+
+    const inlineScripts = [...transformed.matchAll(/<script>([\s\S]*?)<\/script>/g)]
+      .map((match) => match[1])
+    assert.equal(inlineScripts.length, 3, 'polyfill, loader, and trust scripts are inline')
+
+    const browserErrors = []
+    const sandbox = {
+      console: { error: (...args) => browserErrors.push(args.join(' ')) },
+    }
+    sandbox.window = sandbox
+    sandbox.globalThis = sandbox
+    vm.createContext(sandbox)
+    vm.runInContext(inlineScripts[1], sandbox)
+    vm.runInContext(inlineScripts[2], sandbox)
+
+    const loader = sandbox.__ModuleLoader__
+    const factoryOwner = {}
+    const applyOwner = {}
+    const config = { marker: 'config' }
+    const extra = { marker: 'extra' }
+    let factoryThis
+    let factoryRequire
+    let applyThis
+    let applyArgs
+    let publication
+
+    const originalFactory = function (require) {
+      factoryThis = this
+      factoryRequire = require
+      return {
+        inject: [],
+        apply: function () {
+          applyThis = this
+          applyArgs = [...arguments]
+          const [ctx] = arguments
+          const handle = { isLoopback: false }
+          const provided = ctx.provide('connection', handle)
+          return { provided, handle }
+        },
+      }
+    }
+    const queued = {
+      id: '@deepseek-ai/dsh-client-connection',
+      factory: originalFactory,
+      untouched: 'kept',
+    }
+    loader.load(queued)
+    assert.notEqual(queued.factory, originalFactory, 'queue registration factory is wrapped')
+    assert.equal(queued.untouched, 'kept', 'other registration fields are preserved')
+
+    const live = loader.create()
+    assert.equal(live.length, 1)
+    assert.equal(live[0], queued)
+
+    const requireToken = () => {}
+    const connectionExports = queued.factory.call(factoryOwner, requireToken)
+    assert.equal(factoryThis, factoryOwner, 'factory this is preserved')
+    assert.equal(factoryRequire, requireToken, 'factory arguments are preserved')
+    assert.deepEqual(connectionExports.inject, [], 'non-apply exports are preserved')
+
+    const originalProvide = function (service, value) {
+      publication = {
+        thisValue: this,
+        service,
+        descriptor: Object.getOwnPropertyDescriptor(value, 'isLoopback'),
+      }
+      return 'provided'
+    }
+    const clientContext = { provide: originalProvide }
+    const result = connectionExports.apply.call(applyOwner, clientContext, config, extra)
+    assert.equal(applyThis, applyOwner, 'apply this is preserved')
+    assert.deepEqual(applyArgs, [clientContext, config, extra], 'apply arguments are preserved')
+    assert.equal(result.provided, 'provided', 'apply return value is preserved')
+    assert.equal(result.handle.isLoopback, true)
+    assert.deepEqual(publication.descriptor, {
+      value: true,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    }, 'connection is trusted before original ctx.provide observes it')
+    assert.equal(publication.thisValue, clientContext, 'ctx.provide this is preserved')
+    assert.equal(publication.service, 'connection')
+    assert.equal(clientContext.provide, originalProvide, 'ctx.provide is restored after success')
+
+    const otherFactory = () => ({ apply() {} })
+    const other = { id: 'unrelated-client-plugin', factory: otherFactory }
+    loader.load(other)
+    assert.equal(live.at(-1), other)
+    assert.equal(other.factory, otherFactory, 'non-target registrations are untouched')
+
+    const liveLoad = loader.load
+    vm.runInContext(inlineScripts[2], sandbox)
+    assert.equal(loader.load, liveLoad, 'repeated bootstrap does not wrap the live loader again')
+    assert.deepEqual(browserErrors, [])
+
+    const thrown = new Error('connection apply failed')
+    const throwingRegistration = {
+      id: '@deepseek-ai/dsh-client-connection/client',
+      factory: () => ({
+        apply(ctx) {
+          ctx.provide('connection', { isLoopback: false })
+          throw thrown
+        },
+      }),
+    }
+    loader.load(throwingRegistration)
+    const throwingExports = throwingRegistration.factory()
+    const throwingContext = { provide: originalProvide }
+    assert.throws(() => throwingExports.apply(throwingContext), (error) => error === thrown)
+    assert.equal(throwingContext.provide, originalProvide, 'ctx.provide is restored after throw')
+
+    const noLoaderHtml = '<html><head><title>compatibility change</title></head></html>'
+    const fallback1 = capture.transform(noLoaderHtml)
+    const fallback2 = capture.transform(noLoaderHtml)
+    assert.ok(fallback1.includes('crypto.randomUUID'), 'polyfill survives a loader compatibility mismatch')
+    assert.equal(fallback1, fallback2)
+    assert.equal(capture.warnings.length, 1, 'missing loader marker warns only once')
+    assert.match(capture.warnings[0], /module bootstrap not found/)
+  } finally {
+    await capture.cleanup()
+  }
+})
+
+async function captureIndexTransform() {
+  const home = mkdtempSync(join(tmpdir(), 'dsh-auth-gateway-contract-'))
+  const previousHome = process.env.DSH_HOME
+  process.env.DSH_HOME = home
+  await setPassword('GoodPass1')
+
+  const taps = []
+  const disposers = []
+  const warnings = []
+  const ctx = {
+    webServer: {
+      host: '127.0.0.1',
+      tapIndex(transform) {
+        taps.push(transform)
+        return () => {}
+      },
+    },
+    logger: {
+      warn(format, ...args) {
+        warnings.push([format, ...args].join(' '))
+      },
+      info() {},
+    },
+    emit() {},
+    effect(factory) {
+      const dispose = factory()
+      disposers.push(dispose)
+      return dispose
+    },
+  }
+
+  const listenPort = await availablePort()
+  const originalLog = console.log
+  console.log = () => {}
+  try {
+    await mod.apply(ctx, {
+      listenHost: '127.0.0.1',
+      listenPort,
+      upstreamHost: '127.0.0.1',
+      upstreamPort: 9,
+    })
+  } catch (error) {
+    await cleanup()
+    throw error
+  } finally {
+    console.log = originalLog
+  }
+
+  assert.equal(taps.length, 1, 'plugin installs exactly one index transform')
+  return { transform: taps[0], warnings, cleanup }
+
+  async function cleanup() {
+    for (const dispose of disposers.reverse()) {
+      if (typeof dispose === 'function') await dispose()
+    }
+    if (previousHome === undefined) delete process.env.DSH_HOME
+    else process.env.DSH_HOME = previousHome
+    rmSync(home, { recursive: true, force: true })
+  }
+}
+
+function availablePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer()
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const port = server.address().port
+      server.close((error) => {
+        if (error) reject(error)
+        else resolve(port)
+      })
+    })
+  })
+}
 
 function pluginConfig(raw) {
   const plugin = mod.default ?? mod


### PR DESCRIPTION
## 问题背景

当 `dsh-auth-gateway` 通过 LAN 地址提供 Web 页面时，例如：

```bash
dsh web --trusted-host 10.10.50.53:3080
```

浏览器访问 `http://10.10.50.53:3080` 后，登录、聊天以及普通 HTTP/WebSocket 功能可以正常使用，但 `Settings -> Models` 无法加载 provider directory，并提示 `settings are unavailable in this browser`。通过 localhost 访问时表现不同。

## 根因

网关原本已经在代理请求时将发往内部 DSH 的 `Host` / `Origin` 改写为 loopback，因此服务端 privileged API fence 可以正常工作；问题发生在更早的浏览器端初始化阶段。

DSH 的 client connection 根据浏览器当前 hostname 判断是否为 loopback。通过 LAN IP 访问时，初始化出的 `connection.isLoopback` 为 `false`。Settings 等插件随后会立即根据该值选择 settings scope；一旦选择了 memory-only / unavailable scope，再在普通插件加载完成后修改 `connection.isLoopback` 已经太晚。

因此，`--trusted-host` 只能解决服务端接受该 Host 的问题，不能让经过认证的远程浏览器获得与 loopback browser 等价的 client-side trusted state。

这一问题不只影响 Models/provider directory，还会影响依赖 host-backed settings 的功能，包括 Credentials、Locale / Preferences、主题、插件设置、权限或 agent presets、deliverables 等。

## 修复方式

网关现在会在代理返回的 DSH `index.html` 中注入一段 early bootstrap：

1. 保留现有 `crypto.randomUUID` polyfill。
2. 在 DSH 建立 queue-mode `window.__ModuleLoader__` 之后、任何 client module preload 之前安装 hook。
3. 同时覆盖模块加载器的 queue 阶段和 live 阶段，识别 `@deepseek-ai/dsh-client-connection`。
4. 包装 connection plugin 的 `apply()`，并临时包装 `ctx.provide()`。
5. 在 connection service 被发布给后续插件之前，将其 `isLoopback` 定义为 `true`，随后恢复原始 `ctx.provide()`。

关键点是修复发生在 Settings / Models 等插件读取 connection 之前，而不是事后修改已经完成初始化的 connection。

实现还包含以下防护：

- hook 和 plugin 包装均为幂等，避免页面或模块重复处理。
- 非目标模块不受影响。
- 无论 `apply()` 成功还是抛错，都会恢复原始 `ctx.provide()`，不污染后续插件上下文。
- 如果上游 HTML 不再包含预期的 loader 标记，只记录一次警告并保留原页面行为，不会输出半修改的 bootstrap。

## 安全边界

该 bootstrap 只存在于通过 `dsh-auth-gateway` 认证后返回的 DSH 页面中。修复没有改变或绕过以下安全机制：

- 登录认证
- HTTP API authentication
- WebSocket authentication
- 代理的 Host / Origin rewrite
- DSH 服务端 privileged API fence
- 内部 DSH 继续仅监听 loopback

未认证请求仍无法直接取得 DSH 页面/API，也不会被标记为 trusted。

## 测试与验证

- `npm test`：117/117 通过。
- 新增 VM 契约测试，覆盖注入顺序、queue/live 两种 loader 状态、connection 发布时序、非目标模块、幂等、成功/异常时恢复 `ctx.provide()`，以及 loader 标记缺失时的安全行为。
- JavaScript 语法检查通过。
- 已在实际 LAN 访问场景验证：登录、聊天和 WebSocket 正常；`Settings -> Models` 可加载 provider directory，可读取并持久化 Models 配置；其他依赖 host settings 的页面恢复正常。
- 未登录 HTTP API 仍返回 401，未登录页面仍跳转登录，未登录 WebSocket 仍被拒绝。

## 兼容性说明

修复限定在当前 DSH 使用的 `__ModuleLoader__` 和 `@deepseek-ai/dsh-client-connection` 初始化协议内，并通过 marker 检查与失败保护避免在上游页面结构变化时盲目注入。现有 randomUUID polyfill 和网关代理行为保持不变。
