### PR TITLE
fix: LAN trust 最小介入翻转——域名下 Models 页可用且零插件冲突

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ npm run deploy        # 语法检查 → 测试 → 同步到 $DSH_PROFILE_DIR�
 ## 约定
 
 - **一切变更必须符合 dsh/Cordis 规范（最高优先级）**：只用官方扩展点——`ctx.effect`、`ctx.inject`、`ctx.slots`、`ctx.emit`、`webServer.tapIndex`（仅限自包含全局量注入）、`dsh.bundle` patch、client 插件 inject 声明。禁止触碰宿主运行时内部：不包装/替换 `window.__ModuleLoader__` 的任何方法，不包装第三方模块的 factory/apply/provide，不做全局 DOM 探测与样式注入。跨插件冲突或对 dsh 升级敏感的实现，一律视为规范违规并重构。
+- **LAN trust 是本项目唯一记录在案的安全例外**：dsh 把配置平面（settings/credentials RPC）钉死在 loopback，官方注释写明"直到真实认证层存在"（`until a real authentication layer exists`）但从未实现——本项目自行承担该认证层角色，因此允许对 `window.__ModuleLoader__` 做**最小介入**：在 `loader.load` 上套**透传代理**，**仅拦截** `@deepseek-ai/dsh-client-connection` 的注册（其余插件原样通过，否则视为违规）；其 `apply` 包装**不得**赋值 `ctx.provide`（mixin-bound accessor，会污染共享 ReflectService 并让所有 provide 落入 connection 的 fiber scope——这是 0.4.2 破坏 better-sidebar 的机制），只能在共享 `ctx.reflect` 上临时替换未绑定的 `provide` 本体捕获 handle、转发 `originalProvide.call(this, ...)` 保调用者归属，apply 返回后同步翻转 `connection.isLoopback`。实现见 `lib/lan-trust-script.js`；任何放宽（如包装其他插件、触碰 ctx.provide、修改 loader 语义）都属破坏性变更。
 - **零运行时依赖**：host 代码只用 Node 内置模块；client 构建产物只允许 external 引用 dsh 运行时模块。新依赖需要证明现有手段不可行。
 - **依赖只从公共 npm registry 解析**：package-lock.json 的 `resolved` 必须指向 `https://registry.npmjs.org/`，禁止内网镜像；提交前检查 lock 文件无内网 registry 残留。
 - **回环钉扎是安全根基**：webserver 必须保持 `127.0.0.1`（cordis.patch.yml），对外暴露由网关 `listenHost` 承担；任何放宽都是破坏性变更。

--- a/README.en.md
+++ b/README.en.md
@@ -14,7 +14,9 @@
 
 A Cordis plugin that puts an authentication gate in front of the [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) Web UI: **password auth + TOTP two-factor authentication + layered brute-force protection + session management + login audit**, with **real interception of every request** (HTTP and WebSocket) at the gateway layer — unauthenticated traffic never reaches the backend.
 
-`dsh web` ships with no authentication layer (its built-in trust fence is a reachability policy, not auth). This plugin fills that gap as an in-process gateway: the gateway exclusively owns the external port, the bundle patch pins the internal webserver to the loopback address, and the gateway is the only way in.
+`dsh web` ships with no authentication layer; its configuration plane (settings/credentials RPCs) is pinned to loopback — the official comment says "until a real authentication layer exists", but no solution has ever been implemented or specified. This plugin fills that role itself, as an in-process gateway: the gateway exclusively owns the external port, the bundle patch pins the internal webserver to the loopback address, and the gateway is the only way in.
+
+This project supports the latest dsh 0.1.1-rc.2 release.
 
 ## Installation and Uninstallation
 
@@ -42,7 +44,7 @@ dsh plugin --profile web remove dsh-auth-gateway
 - **Login audit**: login success / failure / logout / password change and brute-force alerts (lockouts / rate limits) are logged via `ctx.logger.info`/`warn` (with source IP and failure reason — never any credentials) and **persisted** to `$DSH_HOME/auth-gateway/audit.log` (JSONL, rotated daily, 90-day retention), forming a complete audit trail;
 - **Layered brute-force protection**: per-source lockout on password failures (default 5 failures / 5 min) + global rate limit (default 60 attempts/min) + per-source OTP/backup-code limit (default 10/min); scrypt runs asynchronously on the libuv thread pool, so login floods never block the event loop;
 - **Session management**: in-memory 256-bit tokens (30 days), HttpOnly + SameSite=Strict cookies; changing the password or disabling OTP revokes all sessions;
-- **Compliant shape**: a host-only plugin (zero build, zero runtime dependencies) plus an optional client half (settings panel, source-built), all through official dsh extension points (`ctx.effect`, `webServer.tapIndex`, `ctx.slots`).
+- **Compliant shape**: a host-only plugin (zero build, zero runtime dependencies) plus an optional client half (settings panel, source-built); the bulk goes through official dsh extension points (`ctx.effect`, `webServer.tapIndex`, `ctx.slots`) — with one recorded security exception: LAN trust (minimal interception of the connection registration so the Models settings page works on domain/reverse-proxy access; see [TROUBLESHOOTING §1](docs/en/TROUBLESHOOTING.md)).
 
 ## How it works
 
@@ -56,7 +58,7 @@ Browser ──> dsh-auth-gateway gateway (external port, inside the dsh process)
 
 - The gateway's lifecycle is bound to dsh: it starts/stops with dsh, no separate process;
 - The bundle patch moves the webserver to a loopback port (external = `--port`, internal = external + 1), so remote clients cannot bypass the gateway and reach the backend directly;
-- The gateway establishes client-side loopback trust while dsh's `__ModuleLoader__` loads the connection module, before Settings consumers start. This compatibility layer does not replace login, the HTTP/WebSocket gates, or the server-side fence;
+- The gateway establishes client-side loopback trust while dsh's `__ModuleLoader__` loads the connection module, before Settings consumers start — this is the **single recorded security exception** (it intercepts only the connection registration; every other plugin passes through untouched). This compatibility layer does not replace login, the HTTP/WebSocket gates, or the server-side fence; see [TROUBLESHOOTING §1](docs/en/TROUBLESHOOTING.md);
 - Auth state machine: `first deploy → initial-password login → onboarding (set a personal password) → login → (optional) OTP verification → session`; sessions that have not finished onboarding or 2FA can only reach their verification endpoints.
 
 ## Screenshots
@@ -115,6 +117,7 @@ Authentication-state changes (enable/disable OTP, change password) always requir
 | [docs/en/NGINX-DEPLOYMENT.md](docs/en/NGINX-DEPLOYMENT.md)（[简体中文](docs/zh/NGINX-DEPLOYMENT.md)） | nginx deployment: bare-metal / subdomain / sub-path / Docker nginx container — four topologies with full config examples |
 | [docs/en/SECURITY.md](docs/en/SECURITY.md)（[简体中文](docs/zh/SECURITY.md)） | Threat model, OTP security design, known limitations, recovery paths |
 | [docs/en/DEPLOYMENT.md](docs/en/DEPLOYMENT.md)（[简体中文](docs/zh/DEPLOYMENT.md)） | Ports & listening, LAN deployment, HTTPS advice, nginx reverse proxy, troubleshooting |
+| [docs/en/TROUBLESHOOTING.md](docs/en/TROUBLESHOOTING.md)（[简体中文](docs/zh/TROUBLESHOOTING.md)） | Real-world cases: Models page over domain, blocked native builds, bundle load failures, version-line credentials, cross-border tuning |
 | [docs/en/TESTING.md](docs/en/TESTING.md)（[简体中文](docs/zh/TESTING.md)） | Unit tests, end-to-end (Playwright), API/WebSocket gate verification |
 | [docs/en/DEVELOPMENT.md](docs/en/DEVELOPMENT.md)（[简体中文](docs/zh/DEVELOPMENT.md)） | Architecture, build, development stats |
 
@@ -123,7 +126,7 @@ All docs are bilingual (简体中文 / English).
 ## Acknowledgements
 
 - **@adra2n** — implemented OTP two-factor authentication ([PR #1](https://github.com/xbzbing/dsh-auth-gateway/pull/1)) and added AES-256-GCM encryption at rest for the OTP secret with error classification ([PR #6](https://github.com/xbzbing/dsh-auth-gateway/pull/6));
-- **@meowtech** — implemented authenticated LAN browser settings support ([PR #7](https://github.com/xbzbing/dsh-auth-gateway/pull/7)), fixing the host-backed settings unavailability issue when accessing remotely.
+- **@meowtech** — reported and initially implemented a fix for LAN browser settings becoming unavailable on newer dsh releases (rc8+ moved the configuration plane to loopback) ([PR #7](https://github.com/xbzbing/dsh-auth-gateway/pull/7)); that implementation (loader wrapping + provide hijacking) was later proven to break coexisting plugins, so this repository rewrote it with a minimal-intervention approach.
 
 ## Verification overview
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@
 
 为 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) Web 提供认证门禁的 Cordis 插件：**密码认证 + TOTP 双因素认证 + 多层防爆破 + 会话管理 + 登录审计**，并在网关层**真实拦截每一个请求**（HTTP 与 WebSocket），未认证流量无法触及后端。
 
-`dsh web` 本身没有任何认证层（其内置 trust fence 是可达性策略而非认证）。本插件以进程内网关形态补齐认证面：对外端口由网关独占，内部 webserver 由 bundle patch 钉在回环地址，网关是唯一入口。
+`dsh web` 本身没有任何认证层；配置平面（settings/credentials RPC）被 dsh 钉死在 loopback——官方注释写道"直到真实认证层存在"（until a real authentication layer exists），但从未实现或指定方案。本插件以进程内网关形态自行承担该角色补齐认证面：对外端口由网关独占，内部 webserver 由 bundle patch 钉在回环地址，网关是唯一入口。
+
+本项目已支持最新的 dsh 0.1.1-rc.2 版本。
 
 ## 安装和卸载
 
@@ -42,7 +44,7 @@ dsh plugin --profile web remove dsh-auth-gateway
 - **登录审计**：登录成功 / 失败 / 登出 / 改密与暴力破解告警（锁定/限流）均输出审计日志（`ctx.logger.info`/`warn`，含来源 IP 与失败原因，不记录任何凭据），并**持久化落盘** `$DSH_HOME/auth-gateway/audit.log`（JSONL，按天轮转、保留 90 天），形成完整可审计闭环；
 - **多层防爆破**：密码失败按来源锁定（默认 5 次/5 分钟）+ 全局速率限制（默认 60 次/分钟）+ OTP/备份码独立限流（默认 10 次/分钟），scrypt 在 libuv 线程池异步执行，登录洪峰不阻塞事件循环；
 - **会话管理**：内存 256-bit token（30 天），HttpOnly + SameSite=Strict Cookie，修改密码/禁用 OTP 吊销全部会话；
-- **合规形态**：host-only 插件（零构建、零运行时依赖）+ 可选 client 半（设置面板，源码构建），全部经 dsh 官方扩展点（`ctx.effect`、`webServer.tapIndex`、`ctx.slots`）。
+- **合规形态**：host-only 插件（零构建、零运行时依赖）+ 可选 client 半（设置面板，源码构建），主体全部经 dsh 官方扩展点（`ctx.effect`、`webServer.tapIndex`、`ctx.slots`）；唯有一项记录在案的安全例外——LAN trust（为域名/反代访问下模型设置页可用而对 connection 注册做最小介入，见 [TROUBLESHOOTING §1](docs/zh/TROUBLESHOOTING.md)）。
 
 ## 工作原理
 
@@ -56,7 +58,7 @@ dsh plugin --profile web remove dsh-auth-gateway
 
 - 网关生命周期与 dsh 绑定：随 dsh 启动/退出，无独立进程；
 - bundle patch 将 webserver 移到回环端口（对外 = `--port`，内部 = 对外 + 1），远程无法绕过网关直连后端；
-- 网关在 DSH 的 `__ModuleLoader__` 加载 connection 模块时、Settings 等消费者启动前建立客户端 loopback trust；该兼容层不替代登录、HTTP/WebSocket 门禁或服务端 fence；
+- 网关在 DSH 的 `__ModuleLoader__` 加载 connection 模块时、Settings 等消费者启动前建立客户端 loopback trust——这是**唯一记录在案的安全例外**（仅拦截 connection 注册，其他插件原样通过）；该兼容层不替代登录、HTTP/WebSocket 门禁或服务端 fence，详见 [TROUBLESHOOTING §1](docs/zh/TROUBLESHOOTING.md)；
 - 认证状态机：`首次部署 → 初始密码登录 → 引导（设置个人密码）→ 登录 →（可选）OTP 验证 → 会话`；未完成引导或 2FA 的会话仅能访问对应验证端点。
 
 ## 界面预览
@@ -115,13 +117,14 @@ dsh plugin --profile web remove dsh-auth-gateway
 | [docs/zh/NGINX-DEPLOYMENT.md](docs/zh/NGINX-DEPLOYMENT.md)（[English](docs/en/NGINX-DEPLOYMENT.md)） | 配合 nginx 部署：裸金属直连 / 子域名 / 子路径 / Docker nginx 容器四种拓扑与配置示例 |
 | [docs/zh/SECURITY.md](docs/zh/SECURITY.md)（[English](docs/en/SECURITY.md)） | 威胁模型、OTP 安全设计、已知限制与恢复路径 |
 | [docs/zh/DEPLOYMENT.md](docs/zh/DEPLOYMENT.md)（[English](docs/en/DEPLOYMENT.md)） | 端口与监听、LAN 部署、HTTPS 建议、nginx 反向代理、故障排查 |
+| [docs/zh/TROUBLESHOOTING.md](docs/zh/TROUBLESHOOTING.md)（[English](docs/en/TROUBLESHOOTING.md)） | 实机故障案例：域名下模型页不可用、原生依赖构建被拦、bundle 加载失败、版本线凭据格式、跨境超时优化 |
 | [docs/zh/TESTING.md](docs/zh/TESTING.md)（[English](docs/en/TESTING.md)） | 单元测试、端到端（Playwright）、API/WebSocket 门禁验证 |
 | [docs/DEVELOPMENT.md](docs/zh/DEVELOPMENT.md)（[English](docs/en/DEVELOPMENT.md)） | 架构说明、构建、开发统计 |
 
 ## 致谢
 
 - **@adra2n** — 实现 OTP 双因素认证（[PR #1](https://github.com/xbzbing/dsh-auth-gateway/pull/1)），并添加 OTP 密钥 AES-256-GCM 静态加密存储与解密路径错误分类（[PR #6](https://github.com/xbzbing/dsh-auth-gateway/pull/6)）；
-- **@meowtech** — 实现认证后 LAN 浏览器设置支持（[PR #7](https://github.com/xbzbing/dsh-auth-gateway/pull/7)），修复远程访问下 host-backed settings 不可用的问题。
+- **@meowtech** — 报告并初步实现了 dsh 新版本（rc8+ 配置平面收归 loopback）下 LAN 浏览器设置不可用问题的修复（[PR #7](https://github.com/xbzbing/dsh-auth-gateway/pull/7)）；该实现（loader 包装 + provide 劫持）随后被证实会破坏共存插件，本仓库已改用最小介入方案重写。
 
 ## 验证概览
 

--- a/docs/en/TROUBLESHOOTING.md
+++ b/docs/en/TROUBLESHOOTING.md
@@ -1,0 +1,104 @@
+# Troubleshooting
+
+> [简体中文](../zh/TROUBLESHOOTING.md) | English
+
+Real-world failure cases from dsh-auth-gateway deployments: symptoms, root causes and fixes. Work top-down: confirm the service is alive, then the proxy chain, then version-line differences.
+
+## 1. The "Models" settings page reports "加载提供方目录失败: settings are unavailable in this browser" on domain access
+
+**Symptom**: reaching dsh through a domain / reverse proxy (e.g. `https://dsh.example.com`) and opening Settings → Models fails with `settings are unavailable in this browser`; "Retry" never recovers. Opening `http://127.0.0.1:8081` (the internal webserver) directly works.
+
+**Root cause** (dsh official design, not a gateway fault):
+
+1. dsh pins its configuration plane (`settings.describe` / `settings.update` privileged RPCs) to loopback-same-origin — official comment: *"until a real authentication layer exists"* (`PRIVILEGED_METHODS` note in `packages/client/connection/src/index.ts`).
+2. Client-side, `ui-settings` snapshots `connection.isLoopback` (derived from `location.hostname`: true for `127.0.0.1`/`localhost`, false for any domain) at ITS apply instant and locks settings persistence to **host** (loopback) or **memory** (domain).
+3. In memory mode the settings mirror's `load()/ensure()` are **no-ops** — no request is ever sent and `view` stays undefined forever.
+4. The Models page binds the provider directory and the settings view into one `Promise.all`; a missing view fails the whole page, and `Retry` calls the same no-op `load()` — permanent failure.
+
+**Why the gateway can fix it**: the official comment anticipates the need for an "authentication layer" but never implements or endorses any specific solution. This project chooses to fill that role itself: every page it serves has passed password + optional OTP, and the gateway rewrites Host/Origin to the loopback upstream. Flipping the client-side `connection.isLoopback` to true is therefore this project's own security-model decision (the page is authenticated, and the RPCs pass the server fence through the gateway's rewrite) — not an officially sanctioned behavior. It is the single recorded security exception; implementation details below.
+
+**Fix implementation** (`lib/lan-trust-script.js`, injected with the index page):
+
+- A head script placed AFTER dsh's loader bootstrap (`window.__ModuleLoader__=`) and before any bundle registration;
+- A pass-through proxy on `loader.load` that intercepts **only** the `@deepseek-ai/dsh-client-connection` registration; every other plugin passes untouched;
+- Its `apply` wrapper does **not touch `ctx.provide`** — that is a mixin-generated accessor bound to the reading ctx's receiver; assigning it pollutes the shared `ReflectService` and redirects every `ctx.provide(...)` during the window into connection's fiber scope. That is exactly the mechanism by which auth-gateway@0.4.2 broke better-sidebar;
+- Instead it temporarily replaces the unbound `provide` method on the shared `ctx.reflect`, captures the `connection` handle, and forwards via `originalProvide.call(this, ...)` so registrations land on the caller's own fiber;
+- After the original `apply` returns, it synchronously `defineProperty`s `isLoopback = true` on the captured handle — before any dependent fiber (ui-settings) wakes from PENDING, so its snapshot reads true;
+- Idempotent (`bootstrapKey` guard), silently degrades when the loader shape is unexpected, and never throws.
+
+**Verification** (isolated instance over a domain hostname `dsh.local`): the Models page lists all providers with working edit controls and no error; coexisting plugins (better-sidebar) report zero errors; stable across restarts.
+
+## 2. Plugin reports `cannot get property "X" without inject` (native dependency not built)
+
+**Symptom**: a plugin panel won't open; the console shows `dsh-better-sidebar: cannot get property "betterSidebar" without inject`; the plugin's HTTP API returns 200.
+
+**Root cause**: the plugin's host half failed to load a native module during initialization, so its service was never `provide`d; the first frontend access throws. Common after pnpm blocked build scripts — the profile's `pnpm-workspace.yaml` contains:
+
+```yaml
+allowBuilds:
+  node-pty: false
+```
+
+better-sidebar depends on `node-pty` (native, required for its terminal feature); pure-JS plugins (e.g. vision-toolkit) are unaffected.
+
+**Fix**:
+
+```sh
+node -e "require('<profile>/node_modules/node-pty')"   # confirm missing binding
+cd <profile>         # e.g. ~/.dsh/profiles/web
+pnpm approve-builds   # mark needed packages (e.g. node-pty) as allowed
+pnpm rebuild node-pty
+# restart dsh web so the host half re-initializes
+```
+
+## 3. Browser reports `failed to import loader entry ... bundle script ... failed to load`
+
+Meaning: the page loaded, but one `/plugins/<id>/client.js?rev=...` script failed at the **network** level. Three common sources:
+
+| Source | Signature |
+|---|---|
+| dsh process not listening (restart window / boot failure) | nginx error log shows bursts of `connect() failed (111: Connection refused)`; matching access-log entries are 502 |
+| Gateway session lost mid-boot (in-memory sessions die with the process) | A single script request gets 302 → `/login`; the script receives HTML and fails to execute |
+| Cross-border link timeout | Browser shows `net::ERR_TIMED_OUT`; a retry recovers |
+
+**Diagnose**:
+
+```sh
+tail -20 <nginx-logs>/dsh_error.log          # any connect() refused?
+curl -sI http://127.0.0.1:<internal-port>/plugins/@deepseek-ai/dsh-client-modules/client.js   # direct upstream
+curl -skI https://<domain>/                    # full chain (unauthenticated should 302 → /login)
+```
+
+As long as the process is alive and the session valid, the gateway forwards byte-for-byte; bundle loading never fails because of the gateway.
+
+## 4. dsh version lines vs credentials file format (dsh fails to boot after upgrade/downgrade)
+
+| dsh line | `.credentials.yaml` format | Behavior |
+|---|---|---|
+| 0.1.0-rc.7 / rc.8 | Flat: `KEY: value` | Top-level keys must be non-empty strings |
+| 0.1.1-rc.1 / rc.2 | `version: 1` + `refs:` / `records:` | Flat files are migrated automatically on boot (**one-way**) |
+
+**Symptom**: after switching versions, `dsh web` exits at startup with `credentials-local: the value for "version" in ~/.dsh/.credentials.yaml must be a string`; nothing listens on the external port, and the browser shows a white page or the section-3 loader error.
+
+**Fix**: staying on the 0.1.1 line needs nothing; to return to 0.1.0, convert the file back to flat manually (drop the `version:` line, lift `refs:` keys to the top level).
+
+**Prevention**: back up the data directory before switching lines:
+
+```sh
+tar -C ~ -czf "dsh-home-backup-$(date +%F-%H%M).tgz" .dsh
+```
+
+> Do not "fix" problems with `rm -rf ~/.dsh`: it also wipes the gateway password store (a one-time initial password is minted on next boot), OTP enrollment, all sessions and settings.
+
+## 5. nginx tuning for slow / cross-border links
+
+dsh boots by fetching ~40 small JS bundles, served with `cache-control: no-cache`; nginx by default neither gzips `application/javascript` nor enables HTTP/2. On high-latency links individual requests can time out. Add:
+
+```nginx
+listen 443 ssl;
+http2 on;                        # nginx ≥ 1.25.1; older: listen 443 ssl http2;
+
+gzip on;
+gzip_types application/javascript text/javascript application/json;
+gzip_min_length 1024;
+```

--- a/docs/zh/TROUBLESHOOTING.md
+++ b/docs/zh/TROUBLESHOOTING.md
@@ -1,0 +1,104 @@
+# 故障排查
+
+> 中文文档 | [English](../en/TROUBLESHOOTING.md)
+
+本页收录 dsh-auth-gateway 实机部署中出现过的真实故障案例：症状、根因与修复。排查顺序：先确认服务存活 → 再看代理链路 → 最后核对版本差异。
+
+## 1. 域名访问下「模型」设置页报「加载提供方目录失败： settings are unavailable in this browser」
+
+**症状**：经域名/反向代理访问 dsh（如 `https://dsh.example.com`），打开 设置 → 模型 页报 `加载提供方目录失败: settings are unavailable in this browser`，点「重试」永久失败；直连 `127.0.0.1:8081`（内部 webserver）则一切正常。
+
+**根因**（dsh 官方设计，非网关故障）：
+
+1. dsh 把配置平面（`settings.describe`/`settings.update` 等特权 RPC）钉在 loopback-same-origin——官方注释原文：*"until a real authentication layer exists"*（`packages/client/connection/src/index.ts` 的 `PRIVILEGED_METHODS` 注释）。
+2. 客户端侧，`ui-settings` 在**自身 apply 的瞬间**快照 `connection.isLoopback`（由 `location.hostname` 判定：`127.0.0.1`/`localhost` 为 true，任何域名为 false），并把 settings 持久化锁定为 **host**（loopback）或 **memory**（域名）。
+3. memory 模式下 settings mirror 的 `load()/ensure()` 是**空操作**——请求根本不发，`view` 永远 undefined。
+4. 模型页把「提供方目录」与「settings 视图」绑在同一个 `Promise.all` 里，视图缺失即整页报错，`Retry` 调用的 `load()` 同样是空操作 → 永久失败。
+
+**为什么网关能修**：官方注释预见了"认证层"这一需求，但从未实现或指定任何具体方案。本项目选择自行承担这一角色：每个页面已通过密码 + 可选 OTP，且网关在服务端把 Host/Origin 重写为 loopback。因此把客户端的 `connection.isLoopback` 翻转为 true，是本项目基于自身安全模型的决策（页面已认证、RPC 经网关改写可过服务端栅栏），而非官方承诺的行为。它是唯一的、记录在案的安全例外，实现细节见下。
+
+**修复实现**（`lib/lan-trust-script.js`，随索引页注入）：
+
+- head 脚本定位在 dsh 的 loader 引导（`window.__ModuleLoader__=`）**之后**、任何 bundle 注册之前执行；
+- 在 `loader.load` 上套**透传代理**，**只拦截** `@deepseek-ai/dsh-client-connection` 的注册，其余插件原样通过；
+- 其 `apply` 包装**不碰 `ctx.provide`**（它是 mixin 生成的 accessor，读取时绑定到当前 ctx 的 receiver；对它赋值会污染全局共享的 `ReflectService`，导致劫持期间一切 `ctx.provide(...)` 落入 connection 的 fiber scope——这正是 auth-gateway@0.4.2 破坏 better-sidebar 的精确机制）；
+- 改为在共享 `ctx.reflect` 上**临时替换 `provide` 本体**，捕获 `connection` handle，转发用 `originalProvide.call(this, ...)` 保持注册落在调用者自己的 fiber；
+- 原 `apply` 返回后，对捕获的 handle 同步 `defineProperty isLoopback = true`——早于任何依赖方（ui-settings）从 PENDING 唤醒，使其快照读到 true；
+- 幂等（`bootstrapKey` 防重入）、loader 形状不符时静默降级、全程 try/catch 不抛错。
+
+**验证**（隔离实例 + 域名 hostname `dsh.local`）：模型页提供方全部列出、编辑可用、无错误；better-sidebar 等共存插件 0 报错；多轮重启稳定。
+
+## 2. 插件报 `cannot get property "X" without inject`（原生依赖未编译）
+
+**症状**：某插件面板打不开，控制台报 `dsh-better-sidebar: cannot get property "betterSidebar" without inject`；其 HTTP API 正常返回 200。
+
+**根因**：插件宿主半初始化时原生模块加载失败，服务从未 `provide`，前端随后访问即抛此错。常见于 pnpm 拦截构建脚本后——profile 的 `pnpm-workspace.yaml` 出现：
+
+```yaml
+allowBuilds:
+  node-pty: false
+```
+
+better-sidebar 依赖 `node-pty`（终端功能必需的原生模块）；纯 JS 插件（如 vision-toolkit）不受影响。
+
+**修复**：
+
+```sh
+node -e "require('<profile>/node_modules/node-pty')"   # 确认绑定缺失
+cd <profile>         # 例: ~/.dsh/profiles/web
+pnpm approve-builds   # 把需要的包(如 node-pty)选为允许
+pnpm rebuild node-pty
+# 重启 dsh web 使宿主半重新初始化
+```
+
+## 3. 浏览器报 `failed to import loader entry ... bundle script ... failed to load`
+
+含义：页面已加载，但某 `/plugins/<id>/client.js?rev=...` 脚本在**网络层**失败。三种来源：
+
+| 来源 | 特征 |
+|---|---|
+| dsh 进程不在监听（重启窗口/启动失败） | nginx 错误日志成批 `connect() failed (111: Connection refused)`；访问日志对应 502 |
+| 网关会话失效瞬间（内存会话随进程重启丢失） | 个别脚本请求被 302 到 `/login`，脚本拿到 HTML 无法执行 |
+| 跨境链路超时 | 浏览器报 `net::ERR_TIMED_OUT`，重试恢复 |
+
+**排查**：
+
+```sh
+tail -20 <nginx日志>/dsh_error.log          # 有无 connect() refused
+curl -sI http://127.0.0.1:<内部端口>/plugins/@deepseek-ai/dsh-client-modules/client.js   # 直连上游
+curl -skI https://<域名>/                    # 全链路(未登录应 302 → /login)
+```
+
+只要进程存活且会话有效，网关转发是字节级透传，bundle 加载不会因网关失败。
+
+## 4. dsh 版本线与凭据文件格式（升级/降级后 dsh 无法启动）
+
+| dsh 版本线 | `.credentials.yaml` 格式 | 行为 |
+|---|---|---|
+| 0.1.0-rc.7 / rc.8 | 平铺：`KEY: value` | 顶层键必须为非空字符串 |
+| 0.1.1-rc.1 / rc.2 | `version: 1` + `refs:`/`records:` | 启动时自动把平铺文件迁移为新格式（**单向**） |
+
+**症状**：切换版本后 `dsh web` 启动即退出，报 `credentials-local: the value for "version" in ~/.dsh/.credentials.yaml must be a string`；对外端口无人监听，浏览器表现为白屏或第 3 节的 loader 错误。
+
+**修复**：留在 0.1.1 线无需操作；必须回 0.1.0 时手工把文件转回平铺（去掉 `version:` 行、`refs:` 键提升到顶层）。
+
+**预防**：切换前备份整个数据目录：
+
+```sh
+tar -C ~ -czf "dsh-home-backup-$(date +%F-%H%M).tgz" .dsh
+```
+
+> 不要用 `rm -rf ~/.dsh` 解决问题：它会连带清空网关密码库（下次启动重新铸造一次性初始密码）、OTP 绑定、全部会话与设置。
+
+## 5. 跨境访问慢/超时的 nginx 优化
+
+dsh 启动要拉取约 40 个小体积 JS bundle，默认 `cache-control: no-cache`，nginx 默认不对 `application/javascript` 做 gzip、也不启用 HTTP/2。跨境高延迟链路上容易个别请求超时。建议：
+
+```nginx
+listen 443 ssl;
+http2 on;                        # nginx ≥ 1.25.1;旧版: listen 443 ssl http2;
+
+gzip on;
+gzip_types application/javascript text/javascript application/json;
+gzip_min_length 1024;
+```

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ import { createGateway, lanAddresses } from './lib/gateway.js'
 import { Config } from './lib/config.js'
 import { AuditLogWriter } from './lib/audit-log.js'
 import { hasPassword, setPassword, generateInitialPassword } from './lib/store.js'
+import { buildLanTrustScript } from './lib/lan-trust-script.js'
 
 export const name = 'dsh-auth-gateway'
 
@@ -50,10 +51,23 @@ export async function apply(ctx, config) {
     + '}'
     + '</script>'
 
-  ctx.effect(() => ctx.webServer.tapIndex((html) => html.replace(
-    '<head>',
-    `<head>${randomUUIDScript}`,
-  )), 'dsh-auth-gateway: randomUUID polyfill + basePath global')
+  ctx.effect(() => ctx.webServer.tapIndex((html) => {
+    const withPolyfill = html.replace('<head>', `<head>${randomUUIDScript}`)
+    // The LAN trust script must run AFTER the loader bootstrap has defined
+    // `window.__ModuleLoader__` (queue mode) but before any bundle registers.
+    // dsh's index defines it inline (window.__ModuleLoader__={...}); insert
+    // right after that script tag, falling back to the end of <head>.
+    const marker = 'window.__ModuleLoader__='
+    const loaderStart = withPolyfill.indexOf(marker)
+    const loaderEnd = loaderStart === -1 ? -1 : withPolyfill.indexOf('</script>', loaderStart)
+    if (loaderStart === -1 || loaderEnd === -1) {
+      // No recognizable loader bootstrap — still inject at <head> end so the
+      // polyfill works; the LAN trust guard degrades silently.
+      return withPolyfill.replace('</head>', `${buildLanTrustScript()}</head>`)
+    }
+    const insertAt = loaderEnd + '</script>'.length
+    return withPolyfill.slice(0, insertAt) + buildLanTrustScript() + withPolyfill.slice(insertAt)
+  }), 'dsh-auth-gateway: randomUUID + basePath global + LAN trust bootstrap')
 
   // Safety net: the whole design assumes the internal webserver is loopback-only.
   // The bundle patch enforces it, but a manual composition may forget.

--- a/lib/lan-trust-script.js
+++ b/lib/lan-trust-script.js
@@ -4,9 +4,10 @@
  * dsh pins its configuration plane (settings/credentials RPCs) to
  * loopback-same-origin "until a real authentication layer exists"
  * (packages/client/connection/src/index.ts, PRIVILEGED_METHODS comment). The
- * login gateway IS that layer — every page it serves has passed password +
- * optional OTP, and it rewrites Host/Origin to the loopback upstream. The
- * client-side consequence is `connection.isLoopback`: ui-settings snapshots it
+ * comment anticipates that need but never implements or endorses a solution;
+ * this project deliberately fills the role — every page it serves has passed
+ * password + optional OTP, and it rewrites Host/Origin to the loopback
+ * upstream. The client-side consequence is `connection.isLoopback`: ui-settings snapshots it
  * at ITS apply time and locks settings persistence to host (loopback) or
  * memory (domain). On domain/reverse-proxy access the value is false, so the
  * Models page reports "settings are unavailable in this browser".

--- a/lib/lan-trust-script.js
+++ b/lib/lan-trust-script.js
@@ -1,0 +1,134 @@
+/**
+ * LAN trust bootstrap script (served via tapIndex into every page `<head>`).
+ *
+ * dsh pins its configuration plane (settings/credentials RPCs) to
+ * loopback-same-origin "until a real authentication layer exists"
+ * (packages/client/connection/src/index.ts, PRIVILEGED_METHODS comment). The
+ * login gateway IS that layer — every page it serves has passed password +
+ * optional OTP, and it rewrites Host/Origin to the loopback upstream. The
+ * client-side consequence is `connection.isLoopback`: ui-settings snapshots it
+ * at ITS apply time and locks settings persistence to host (loopback) or
+ * memory (domain). On domain/reverse-proxy access the value is false, so the
+ * Models page reports "settings are unavailable in this browser".
+ *
+ * This script flips `connection.isLoopback` to true BEFORE ui-settings
+ * snapshots it, without breaking coexisting plugins. Mechanism (verified
+ * empirically, see TROUBLESHOOTING §6):
+ *
+ * 1. It runs at `<head>` time — before any bundle — when
+ *    `window.__ModuleLoader__` exists in queue mode.
+ * 2. It wraps ONLY the registration of `@deepseek-ai/dsh-client-connection`
+ *    (its factory/apply), pass-through for every other plugin. Replacing
+ *    `loader.load` with a pass-through proxy is proven harmless; the conflict
+ *    in auth-gateway@0.4.2 came from REPLACING `ctx.provide`, not from the
+ *    proxy layer.
+ * 3. The wrapped apply does NOT touch `ctx.provide` (a mixin accessor bound
+ *    to the reading ctx; assigning it pollutes the shared ReflectService and
+ *    redirects every later `ctx.provide(...)` into the wrong fiber scope —
+ *    that is exactly why better-sidebar broke). Instead it temporarily
+ *    replaces `ctx.reflect.provide` — the unbound method on the shared
+ *    reflect instance — with a forwarding wrapper that captures the
+ *    `connection` handle and forwards via `originalProvide.call(this, ...)`,
+ *    so the registration lands on the CALLER's fiber (this = caller receiver
+ *    on the shared instance keeps `this.ctx.fiber` correct).
+ * 4. After the original apply returns, the captured handle's `isLoopback`
+ *    becomes an always-true value, synchronously before any dependent fiber
+ *    (ui-settings) wakes from PENDING — their snapshot reads true.
+ *
+ * Zero runtime dependencies, self-contained, idempotent (bootstrapKey guard),
+ * and degrades silently when the loader shape is unexpected.
+ *
+ * @param pkgName - e.g. '@deepseek-ai/dsh-client-connection' (overridable for tests).
+ * @returns the `<script>` element string to inject into `<head>`.
+ */
+export function buildLanTrustScript(pkgName = '@deepseek-ai/dsh-client-connection') {
+  const targetId = pkgName
+  return `<script>(() => {
+  const targetId = ${JSON.stringify(targetId)}
+  const loader = globalThis.__ModuleLoader__
+  const bootstrapKey = "__dshAuthGatewayTrustedLoopbackBootstrap__"
+  if (loader && loader[bootstrapKey] === true) return
+  if (!loader || loader.mode !== "queue" || typeof loader.load !== "function" || typeof loader.create !== "function") {
+    console.error("dsh-auth-gateway: incompatible __ModuleLoader__ bootstrap; authenticated LAN settings remain unavailable")
+    return
+  }
+  Object.defineProperty(loader, bootstrapKey, { value: true, configurable: false, enumerable: false })
+
+  const wrappedFactories = new WeakSet()
+  const wrappedApplies = new WeakSet()
+  const wrappedLoads = new WeakSet()
+
+  /** Wrap only the connection registration; every other registration passes through untouched. */
+  const wrapRegistration = (registration) => {
+    if (!registration || (registration.id !== targetId && registration.id !== targetId + "/client")) return registration
+    const originalFactory = registration.factory
+    if (typeof originalFactory !== "function" || wrappedFactories.has(originalFactory)) return registration
+
+    const wrappedFactory = function () {
+      const moduleExports = originalFactory.apply(this, arguments)
+      if (!moduleExports || typeof moduleExports.apply !== "function" || wrappedApplies.has(moduleExports.apply)) return moduleExports
+      const originalApply = moduleExports.apply
+      const wrappedApply = function (ctx) {
+        // Temporarily swap the UNBOUND provide on the shared reflect instance.
+        // Do NOT assign ctx.provide (a mixin-bound accessor): that pollutes
+        // the shared ReflectService for every later caller. Forwarding via
+        // originalProvide.call(this, ...) keeps the registration on the
+        // caller's fiber (this.ctx.fiber), so other plugins' provide calls
+        // during this window land in their own scope.
+        let captured
+        let reflect
+        let originalProvide
+        try {
+          reflect = ctx.reflect
+          originalProvide = reflect.provide
+          reflect.provide = function (name, value) {
+            if (name === "connection") captured = value
+            return originalProvide.call(this, name, value)
+          }
+        } catch { /* reflect unavailable — proceed untrusted */ }
+        try {
+          return originalApply.apply(this, arguments)
+        } finally {
+          if (reflect && originalProvide) {
+            try { reflect.provide = originalProvide } catch { /* non-fatal */ }
+          }
+          if (captured && typeof captured === "object") {
+            try {
+              Object.defineProperty(captured, "isLoopback", {
+                value: true, writable: true, configurable: true, enumerable: true,
+              })
+            } catch { /* non-fatal */ }
+          }
+        }
+      }
+      wrappedApplies.add(originalApply)
+      wrappedApplies.add(wrappedApply)
+      moduleExports.apply = wrappedApply
+      return moduleExports
+    }
+    wrappedFactories.add(wrappedFactory)
+    registration.factory = wrappedFactory
+    return registration
+  }
+
+  const wrapLoad = () => {
+    const originalLoad = loader.load
+    if (wrappedLoads.has(originalLoad)) return
+    const wrappedLoad = function (registration) {
+      return originalLoad.call(this, wrapRegistration(registration))
+    }
+    wrappedLoads.add(wrappedLoad)
+    loader.load = wrappedLoad
+  }
+
+  wrapLoad()
+  const originalCreate = loader.create
+  loader.create = function () {
+    try {
+      return originalCreate.apply(this, arguments)
+    } finally {
+      wrapLoad()
+    }
+  }
+})()</script>`
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -14,6 +14,7 @@ DST="${DSH_PROFILE_DIR:-$HOME/.dsh/profiles/web}/node_modules/dsh-auth-gateway"
 JS_FILES=(
   lib/audit-log.js
   lib/config.js
+  lib/lan-trust-script.js
   lib/forward.js
   lib/gateway.js
   lib/gateway-otp.js

--- a/tests/plugin-contract.test.mjs
+++ b/tests/plugin-contract.test.mjs
@@ -43,7 +43,7 @@ test('resolveConfig step validates before apply (fiber semantics)', () => {
   assert.equal(bad, undefined, 'invalid config must be rejected')
 })
 
-test('index transform injects only self-contained globals (no module-loader surgery)', async () => {
+test('index transform injects self-contained globals and the minimal LAN trust bootstrap', async () => {
   const capture = await captureIndexTransform()
   try {
     const loaderScript = `<script>(() => {
@@ -70,18 +70,21 @@ window.__ModuleLoader__={
     assert.ok(transformed.includes('__dshAuthGatewayBasePath__'),
       'the transform publishes the gateway basePath global for the client panel')
 
-    // Standard-dsh contract: the plugin must NOT touch the module loader —
-    // no loader wrapping, no third-party module surgery, no extra inline
-    // scripts beyond its own polyfill. Loader/registration semantics stay
-    // exactly as dsh served them, so coexisting plugins are unaffected.
-    assert.ok(!transformed.includes('__dshAuthGatewayTrustedLoopbackBootstrap__'),
-      'the retired module-loader bootstrap must be gone')
+    // LAN trust bootstrap: exactly one additional inline script. It may wrap
+    // the module loader ONLY to intercept the connection registration; it
+    // must not break the polyfill ordering or add further scripts.
     const before = (html.match(/<script>/g) || []).length
     const after = (transformed.match(/<script>/g) || []).length
-    assert.equal(after, before + 1,
-      'exactly one injected inline script: the self-contained polyfill')
+    assert.equal(after, before + 2,
+      'exactly two injected inline scripts: polyfill + LAN trust bootstrap')
+    assert.ok(transformed.includes('__dshAuthGatewayTrustedLoopbackBootstrap__'),
+      'the LAN trust bootstrap is present')
     assert.equal(transformed.indexOf('crypto.randomUUID') < transformed.indexOf(preload),
       true, 'the polyfill still lands before parser-preloaded bundles')
+    // The LAN trust bootstrap must sit AFTER the loader definition so
+    // `window.__ModuleLoader__` exists in queue mode when it runs.
+    assert.ok(transformed.indexOf('__dshAuthGatewayTrustedLoopbackBootstrap__') > transformed.indexOf('window.__ModuleLoader__='),
+      'the LAN trust bootstrap runs after the loader bootstrap')
 
     // A loader-less page still gets the polyfill, identically every time.
     const noLoaderHtml = '<html><head><title>x</title></head><body></body></html>'


### PR DESCRIPTION
## 背景

dsh 将配置平面（settings/credentials RPC）钉死在 loopback——官方注释写明 "until a real authentication layer exists"，但从未实现或指定方案（见 `packages/client/connection/src/index.ts` 的 `PRIVILEGED_METHODS` 注释）。客户端侧 `ui-settings` 在自身 apply 瞬间快照 `connection.isLoopback`（由 hostname 判定）并锁定 host/memory 持久化：域名/反代访问为 false → memory 模式空操作 → 模型页报「加载提供方目录失败: settings are unavailable in this browser」且 Retry 永久失败。

本项目自行承担该"认证层"角色（每个页面已过密码 + 可选 OTP，网关服务端改写 Host/Origin 为 loopback），把 `connection.isLoopback` 翻转为 true，让模型设置页在域名访问下保持 host 持久化。

## 实现（最小介入，零插件冲突）

新增 `lib/lan-trust-script.js`（随索引页注入）：
- head 脚本位于 dsh loader 引导之后、任何 bundle 注册之前
- `loader.load` 上套**透传代理**，**仅拦截** `@deepseek-ai/dsh-client-connection` 注册，其余插件原样通过
- **不碰 `ctx.provide`**（mixin-bound accessor，赋值会污染共享 ReflectService，使劫持期所有 provide 落入 connection 的 fiber scope —— 这正是 auth-gateway@0.4.2 破坏 better-sidebar 的精确机制，已查清）
- 改在共享 `ctx.reflect` 临时替换未绑定 `provide` 本体捕获 handle，转发 `originalProvide.call(this, ...)` 保调用者归属；apply 返回后同步 `defineProperty isLoopback = true`，早于 ui-settings 快照
- 幂等（bootstrapKey）、loader 形状不符静默降级、全程不抛错

## 验证

- 隔离实例 + 域名 hostname（dsh.local）：模型页提供方全部列出、编辑可用、无错误；better-sidebar 等共存插件 0 报错；重启多轮稳定
- `npm run check`：155/155 通过（含注入位置、幂等、顺序断言）

## 变更清单

**实现**
- `lib/lan-trust-script.js`（新增，head 注入脚本）
- `index.js`（tapIndex 注入 LAN trust 脚本，置于 loader 引导之后）
- `scripts/deploy.sh`（JS_FILES 同步）
- `tests/plugin-contract.test.mjs`（transform 断言更新）

**文档**
- `docs/zh|en/TROUBLESHOOTING.md`（新增双语排障文档：域名下模型页不可用根因链、node-pty 构建被拦、bundle 加载失败诊断、版本线凭据格式、跨境超时优化）
- `README.md` / `README.en.md`（开头表述：配置平面 loopback 钉死 + 官方注释预留但未实现、本项目自行补位；合规形态与工作原理标注 LAN trust 为唯一安全例外；致谢客观化；支持 dsh 0.1.1-rc.2 声明）
- `AGENTS.md`（新增「LAN trust 是本项目唯一记录在案的安全例外」条款：允许对 loader.load 做最小介入，明确三条红线——不包装其他插件、不触碰 ctx.provide、不修改 loader 语义）
