### PR TITLE
feat: 审计日志迁至 log/ 子目录 + auth-gate 迁移加固

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ lib/
   gateway-otp.js OTP 路由 handler（自 gateway.js 拆分，经 priv 桥接访问网关私有方法）
   forward.js    HTTP/WS 转发管道：Host/Origin 回环改写、upgrade 双向管道、lanAddresses
   auth.js       内存会话表（256-bit token）+ Cookie 编解码
-  audit-log.js  审计日志文件 sink（JSONL，$DSH_HOME/auth-gateway/audit.log，按天轮转、保留 90 天）
+  audit-log.js  审计日志文件 sink（JSONL，$DSH_HOME/auth-gateway/log/audit.log，按天轮转、保留 90 天）
   locale.js     页面语言解析（settings.yaml preference > Accept-Language > zh）
   errors.js     页面错误文案总字典（中英；errorsFor 按页选取 + 场景覆盖）
   store.js      密码存储（异步 scrypt，$DSH_HOME/auth-gateway/password.json）

--- a/lib/audit-log.js
+++ b/lib/audit-log.js
@@ -7,7 +7,7 @@
  * `{kind, ip, reason?}` payloads the plugin maps onto `ctx.logger.info` and
  * the brute-force security events (`lockout`, `global-rate-limit`,
  * `otp-rate-limit`, with their structured fields) are appended as JSON Lines
- * to $DSH_HOME/auth-gate/audit.log.
+ * to $DSH_HOME/auth-gateway/log/.
  *
  * Retention: the live file rolls over once per local calendar day
  * (audit.log -> audit.log.<YYYY-MM-DD>), and rotated files older than
@@ -40,9 +40,9 @@
 
 import { chmod, link, mkdir, readdir, appendFile, stat, unlink } from 'node:fs/promises'
 import { join } from 'node:path'
-import { credentialDir } from './paths.js'
+import { auditLogDir } from './paths.js'
 
-/** Name of the live (today) audit file inside the auth-gate directory. */
+/** Name of the live (today) audit file inside the log subdirectory. */
 export const AUDIT_LOG_NAME = 'audit.log'
 
 /** Rotated archives older than this many days are deleted (at most). */
@@ -65,11 +65,6 @@ export function dayString(ts) {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
 }
 
-/** Directory holding the audit trail (same owner-only dir as password.json). */
-export function auditLogDir() {
-  return credentialDir()
-}
-
 /**
  * Append-only audit writer for one directory.
  *
@@ -80,7 +75,7 @@ export class AuditLogWriter {
   /**
    * @param {object} [options]
    * @param {string} [options.dir] - target directory (tests override; default
-   *   $DSH_HOME/auth-gate).
+   *   $DSH_HOME/auth-gateway/log/).
    * @param {() => number} [options.now] - injectable clock (ms epoch).
    * @param {number} [options.maxAgeDays] - archive retention in days.
    * @param {(err: Error) => void} [options.onError] - write-failure sink

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -12,7 +12,7 @@
  * the legacy copy is left untouched rather than merged.
  */
 
-import { existsSync, mkdirSync, renameSync } from 'node:fs'
+import { existsSync, mkdirSync, renameSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import os from 'node:os'
 
@@ -47,12 +47,23 @@ export function credentialDir() {
   if (!migrated) {
     migrated = true
     const legacy = join(home, LEGACY_DIR_NAME)
-    try {
-      // POSIX rename moves a directory onto an absent target atomically;
-      // the new directory must not pre-exist, which the guard above ensures.
-      if (!existsSync(dir) && existsSync(legacy)) renameSync(legacy, dir)
-    } catch {
-      // Fall through: the caller creates/uses the new directory fresh.
+    // Only a real directory migrates: a stray file named `auth-gate` is left
+    // in place rather than renamed over the credential directory's name.
+    if (isDirectory(legacy) && !existsSync(dir)) {
+      try {
+        // POSIX rename moves a directory onto an absent target atomically;
+        // the new directory must not pre-exist, which the guard above ensures.
+        renameSync(legacy, dir)
+      } catch (err) {
+        // A failed rename (e.g. EXDEV across mounts) must be loud: the
+        // gateway would otherwise start with a fresh credential dir and mint
+        // a new initial password while the old credentials sit untouched.
+        console.error(
+          `[dsh-auth-gateway] failed to migrate ${legacy} -> ${dir}:`,
+          err instanceof Error ? err.message : err,
+          '— move it manually or remove it, then restart.',
+        )
+      }
     }
   }
   return dir
@@ -63,4 +74,25 @@ export function ensureCredentialDir() {
   const dir = credentialDir()
   mkdirSync(dir, { recursive: true, mode: 0o700 })
   return dir
+}
+
+/**
+ * The audit trail directory: `$DSH_HOME/auth-gateway/log/`.
+ *
+ * Kept as a subdirectory of the credential dir so backups and permissions can
+ * be managed per-tree, while staying separate from the secret files at the
+ * root. Created (0700) on first use by the audit writer.
+ * @returns {string} absolute path of the audit log directory.
+ */
+export function auditLogDir() {
+  return join(credentialDir(), 'log')
+}
+
+/** True when path exists and is a directory (files masquerading as one are skipped by migrations). */
+function isDirectory(path) {
+  try {
+    return statSync(path).isDirectory()
+  } catch {
+    return false
+  }
 }

--- a/tests/paths.test.mjs
+++ b/tests/paths.test.mjs
@@ -95,3 +95,32 @@ test('store.js resolves its password file under the migrated directory', async (
     delete process.env.DSH_HOME
   }
 })
+
+test('a stray file named auth-gate is skipped by the migration (left in place)', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'dsh-paths-file-'))
+  try {
+    const stray = join(home, 'auth-gate')
+    writeFileSync(stray, 'not a directory\n')
+
+    const { credentialDir } = await freshPaths(home)
+    const dir = credentialDir()
+
+    assert.equal(dir, join(home, 'auth-gateway'))
+    assert.ok(existsSync(stray), 'the stray file is left untouched (no rename over it)')
+    assert.ok(!existsSync(join(home, 'auth-gateway', 'password.json')) || true,
+      'the gateway proceeds with a fresh directory')
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('auditLogDir resolves under the auth-gateway log subdirectory', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'dsh-paths-audit-'))
+  try {
+    const { auditLogDir } = await freshPaths(home)
+    const dir = auditLogDir()
+    assert.equal(dir, join(home, 'auth-gateway', 'log'))
+  } finally {
+    rmSync(home, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## 背景

此前审计日志与凭据文件（password.json、OTP 密钥）混放在 `auth-gateway/` 根目录。本 PR 将审计日志迁至独立子目录 `auth-gateway/log/`，实现：

- **语义分离**：根目录只保留敏感凭据（password.json / otp.json / otp-master.key），日志归 `log/` 子目录，备份与权限管理可差异化
- **权限独立可调**：将来日志收集工具只需放宽 `log/` 目录权限，不触碰凭据
- **扩展位**：后续其他日志有归属地

## 变更

### 1. 审计目录：`auth-gateway/log/`

- 新增 `paths.auditLogDir()` 返回 `$DSH_HOME/auth-gateway/log/`
- `audit-log.js` 默认目录改用新函数；目录 `0700`、文件 `0600`（创建即收紧）
- **旧位置的审计文件不做迁移**——新写入直接落 `log/`，旧归档留原地由使用者自行处置

### 2. auth-gate → auth-gateway 迁移加固

审查发现的两个边界，本次一并修复：

| 边界 | 原行为 | 修复后 |
|---|---|---|
| `auth-gate` 是普通文件而非目录 | existsSync 误判 → rename 把文件改名成目录名 → 后续报错被静默吞掉、残留垃圾 | `isDirectory()` 校验，非目录跳过迁移 |
| rename 失败（如 EXDEV 跨设备挂载） | 静默吞掉降级为全新目录 → 凭据"被遗忘"，等同**静默重置** | 显式 `console.error` 提示手工处理路径 |

## 兼容性说明（重要）

`auth-gate` → `auth-gateway` 的目录改名迁移是为兼容早期版本的**过渡性功能**：它保证旧部署升级时凭据（密码、OTP 绑定、审计轨迹）不丢失。

**计划在版本稳定后放弃对早期版本目录的兼容**（届时直接使用新目录、不再探测 legacy 路径），以精简代码路径、消除上述静默降级分支，提高系统可靠性。届时如有用户仍停留在极老版本，需按文档手工迁移。

同理，本次审计日志的旧位置文件也**不做自动迁移**——遵循同一原则：迁移代码是临时的兼容层，不是长期维护面。

## 测试

- `tests/paths.test.mjs` 新增 2 例：stray 同名文件跳过迁移、`auditLogDir()` 路径断言；既有 4 例迁移用例全过
- 端到端（隔离实例 + 登录触发审计）：日志落 `auth-gateway/log/audit.log`（0700 目录 / 0600 文件），JSONL 格式不变，根目录无残留
